### PR TITLE
Fix/#3

### DIFF
--- a/projects/fluig-api/package.json
+++ b/projects/fluig-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluig-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "description": "Angular service and HttpClient Interceptor for handling authentication in Fluig platform applications during local development.",
   "author": "Gabriel Nascimento",

--- a/projects/fluig-api/src/lib/fluig-api.service.ts
+++ b/projects/fluig-api/src/lib/fluig-api.service.ts
@@ -115,13 +115,18 @@ export class FluigAPIService {
       throw new Error('[FluigAPI] OAuth configuration is missing');
     }
 
-    const absoluteUrl = new URL(
+    const url = new URL(
       this.getUrlWithParams(request.url, request?.options?.params),
       this.cfg.url
-    ).toString();
+    );
+
+    // OAuth 1.0a requires base URL (without query) + structured params
+    // to ensure signature base string matches server expectations exactly.
+    // Parsing query from full URL can cause subtle differences (empty values, duplicates).
+    const baseUrl = `${url.origin}${url.pathname}`;
 
     const authOptions = {
-      url: absoluteUrl,
+      url: baseUrl,
       method: request.method.toUpperCase(),
       includeBodyHash: false,
       data: undefined,
@@ -130,6 +135,22 @@ export class FluigAPIService {
     if (['POST', 'PUT', 'PATCH'].includes(request.method)) {
       authOptions.includeBodyHash = true;
       authOptions.data = request.data;
+    } else {
+      const queryParams: Record<string, string | string[]> = {};
+      // Preserve existing query parameters in the URL
+      url.searchParams.forEach((value, key) => {
+        if (Object.prototype.hasOwnProperty.call(queryParams, key)) {
+          const prev = queryParams[key];
+          if (Array.isArray(prev)) prev.push(value);
+          else queryParams[key] = [prev as string, value];
+        } else {
+          queryParams[key] = value;
+        }
+      });
+
+      authOptions.data = Object.keys(queryParams).length
+        ? (queryParams as any)
+        : undefined;
     }
 
     return this.oauth.authorize(
@@ -2055,6 +2076,7 @@ export class FluigAPIService {
       headers: this.getAuthHeader({
         method: 'PATCH',
         url,
+        data: body,
         options: {
           headers: params?.headers,
           params: params?.params,
@@ -2756,6 +2778,7 @@ export class FluigAPIService {
       headers: this.getAuthHeader({
         method: 'POST',
         url,
+        data: body,
         options: {
           headers: params?.headers,
           params: params?.params,
@@ -3381,6 +3404,7 @@ export class FluigAPIService {
       headers: this.getAuthHeader({
         method: 'PUT',
         url,
+        data: body,
         options: {
           headers: params?.headers,
           params: params?.params,

--- a/projects/fluig-api/src/lib/fluig-api.service.ts
+++ b/projects/fluig-api/src/lib/fluig-api.service.ts
@@ -100,10 +100,12 @@ export class FluigAPIService {
         >
   ) {
     if (params == null) return url;
-    const httpParams =
+    const httpParams: HttpParams =
       params instanceof HttpParams
-        ? new HttpParams({ fromString: params.toString() })
-        : new HttpParams({ fromObject: params });
+        ? params
+        : typeof params === 'string'
+          ? new HttpParams({ fromString: params })
+          : new HttpParams({ fromObject: params });
     const paramString = httpParams.toString();
     return paramString ? `${url}?${paramString}` : url;
   }


### PR DESCRIPTION
This pull request updates the `fluig-api` package to improve OAuth 1.0a request signing accuracy, especially in how URLs and parameters are handled. The changes ensure that the signature base string matches server expectations, which is critical for authentication to work correctly. Additionally, the request body is now explicitly included in the OAuth signature for methods that send data.

Key improvements include:

**OAuth 1.0a Signature Accuracy:**

* Refactored the URL handling in `FluigAPIService` to use the base URL (excluding query parameters) for OAuth signing, preventing subtle mismatches in the signature base string. Query parameters are now structured and passed separately to the OAuth signature generator. [[1]](diffhunk://#diff-7628113ed74ca14f574d40c25186bb5efdd58e8cad5487b3a05e9f2aa83e5de7L116-R129) [[2]](diffhunk://#diff-7628113ed74ca14f574d40c25186bb5efdd58e8cad5487b3a05e9f2aa83e5de7R138-R153)

* Improved parameter handling in `getUrlWithParams` to correctly process `HttpParams`, string, or object types, avoiding unnecessary conversions and ensuring parameter consistency.

**Request Body Handling:**

* Added the request body (`data`) explicitly to the OAuth signature options for `PATCH`, `POST`, and `PUT` methods, ensuring the body is included in the signature calculation as required by OAuth 1.0a. [[1]](diffhunk://#diff-7628113ed74ca14f574d40c25186bb5efdd58e8cad5487b3a05e9f2aa83e5de7R2079) [[2]](diffhunk://#diff-7628113ed74ca14f574d40c25186bb5efdd58e8cad5487b3a05e9f2aa83e5de7R2781) [[3]](diffhunk://#diff-7628113ed74ca14f574d40c25186bb5efdd58e8cad5487b3a05e9f2aa83e5de7R3407)

**Version Update:**

* Bumped the package version from `1.0.1` to `1.0.2` to reflect these improvements.